### PR TITLE
Remove local maven repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     pluginLibs group: 'stax-api', name: 'stax-api', version: '1.0.1'
     pluginLibs group: 'aws-java-sdk', name: 'aws-java-sdk', version: '1.0.12'
     
-    compile group: 'org.rundeck', name: 'rundeck-core', version: '1.5'
+    compile group: 'org.rundeck', name: 'rundeck-core', version: '1.6.0'
 }
 
 // task to copy plugin libs to output/lib dir


### PR DESCRIPTION
I think you hit the following Gradle bug:

http://issues.gradle.org/browse/GRADLE-2034

If I try to build the jar, I get the following error:

> A problem occurred evaluating root project 'rundeck-ec2-nodes-plugin'.
> Could not resolve all dependencies for configuration ':pluginLibs'.
> Artifact 'commons-logging:commons-logging:1.0.3@jar' not found.

The reason is, this specific version isn't in my local repository (I use a newer version in  an other project). If I remove the mavenLocal() everything works fine.
