### PR TITLE
Add support for setting ssh port

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -74,6 +74,8 @@ Here is the default mapping:
     description.default=EC2 node instance
     editUrl.default=https://console.aws.amazon.com/ec2/home#s=Instances&selectInstance=${node.instanceId}
     hostname.selector=publicDnsName
+    sshport.default=22
+    sshport.selector=tags/ssh_config_Port
     instanceId.selector=instanceId
     nodename.selector=tags/Name,instanceId
     osArch.selector=architecture
@@ -175,6 +177,7 @@ Rundeck nodes have the following metadata fields:
 
 * `nodename` - unique identifier
 * `hostname` - IP address/hostname to connect to the node
+* `sshport` - The ssh port, if resolved to another port than 22 hostname will be set to ``<hostname>:<sshport>``
 * `username` - SSH username to connect to the node
 * `description` - textual description
 * `osName` - OS name

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSource.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSource.java
@@ -78,6 +78,8 @@ public class EC2ResourceModelSource implements ResourceModelSource {
     static {
         final String mapping = "nodename.selector=tags/Name,instanceId\n"
                                + "hostname.selector=publicDnsName\n"
+                               + "sshport.default=22\n"
+                               + "sshport.selector=tags/ssh_config_Port\n"
                                + "description.default=EC2 node instance\n"
                                + "osArch.selector=architecture\n"
                                + "osFamily.selector=platform\n"

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapper.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapper.java
@@ -322,6 +322,12 @@ class InstanceToNodeMapper {
         }
         node.setNodename(name);
 
+        // Set ssh port on hostname if not 22
+        String sshport = node.getAttributes().get("sshport");
+        if (sshport != null && !sshport.equals("") && !sshport.equals("22")) {
+            node.setHostname(node.getHostname() + ":" + sshport);
+        }
+
         return node;
     }
 

--- a/src/main/resources/defaultMapping.properties
+++ b/src/main/resources/defaultMapping.properties
@@ -17,6 +17,8 @@
 description.default=EC2 node instance
 editUrl.default=https://console.aws.amazon.com/ec2/home#Instances:search=${node.instanceId}
 hostname.selector=publicDnsName
+sshport.default=22
+sshport.selector=tags/ssh_config_Port
 instanceId.selector=instanceId
 nodename.selector=tags/Name,instanceId
 osArch.selector=architecture


### PR DESCRIPTION
Some systems run multiple ssh servers, for instance if they host SFTP servers. 
In that case its nice to be able to configure a different ssh port for rundeck to use on some EC2 instances.

Rundeck would like the ssh port to be part of the hostname like this ``<hostname>:<port>``
Setting a sshport.selector will append that port to the hostname if its different from 22.
