### PR TITLE
Allow conjoined selector values using +

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -169,6 +169,25 @@ The tags.selector also supports a "merge" ability, so you can merge multiple Ins
 
     tags.selector=tags/Environment|tags/Role
 
+### Appending values
+
+A field selector can conjoin multiple values using `+`, and can append literal text like the `_` character for example.
+
+    # conjoin two fields with no separation between the values
+    # this will result in "field1field2" 
+    <attribute>.selector=<field selector>+<field2 selector>
+    
+    # conjoin multiple fields with a literal string delimiter
+    # this will result in "field1-*-field2"
+    <attribute>.selector=<field selector>+"-*-"+<field2 selector>
+
+Use a quoted value to insert a delimiter, with either single or double quotes.
+
+Here is an example to use the "Name" instance tag, and InstanceId, to generate
+a unique node name for rundeck:
+
+    nodename.selector=tags/Name+'-'+instanceId
+
 
 Mapping EC2 Instances to Rundeck Nodes
 =================

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 apply plugin: 'java'
+apply plugin: 'groovy'
 apply plugin: 'idea'
 apply plugin: 'pl.allegro.tech.build.axion-release'
 sourceCompatibility = 1.6
@@ -63,6 +64,9 @@ dependencies {
 
     pluginLibs group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '1.9.0'
     pluginLibs group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: '1.9.0'
+
+    testCompile "org.codehaus.groovy:groovy-all:2.3.7"
+    testCompile "org.spockframework:spock-core:0.7-groovy-2.0"
 }
 
 // task to copy plugin libs to output/lib dir

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapper.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapper.java
@@ -379,7 +379,7 @@ class InstanceToNodeMapper {
         return defaultValue;
     }
 
-    private static String applySingleSelector(final Instance inst, final String selector) throws
+    static String applySingleSelector(final Instance inst, final String selector) throws
         GeneratorException {
         if (null != selector && !"".equals(selector) && selector.startsWith("tags/")) {
             final String tag = selector.substring("tags/".length());

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapper.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapper.java
@@ -357,7 +357,7 @@ class InstanceToNodeMapper {
                 if (tagMerge) {
                     final StringBuilder sb = new StringBuilder();
                     for (final String subPart : selPart.split(Pattern.quote("|"))) {
-                        final String val = applySingleSelector(inst, subPart);
+                        final String val = applyMultiSelector(inst, subPart.split(Pattern.quote("+")));
                         if (null != val) {
                             if (sb.length() > 0) {
                                 sb.append(",");
@@ -369,7 +369,7 @@ class InstanceToNodeMapper {
                         return sb.toString();
                     }
                 } else {
-                    final String val = applySingleSelector(inst, selPart);
+                    final String val = applyMultiSelector(inst, selPart.split(Pattern.quote("+")));
                     if (null != val) {
                         return val;
                     }
@@ -379,6 +379,41 @@ class InstanceToNodeMapper {
         return defaultValue;
     }
 
+    private static final Pattern quoted = Pattern.compile("^(['\"])(.+)\\1$");
+
+    /**
+     * Return conjoined multiple selector and literal values only if some selector value matches, otherwise null.
+     * Apply multiple selectors and separators to determine the value, the selector values are conjoined
+     * in order if they resolve to a non-blank value. If a selector is a quoted string, the contents are
+     * conjoined literally
+     *
+     * @param inst
+     * @param selectors
+     *
+     * @return conjoined selector values with literal separators, if some selector was resolved, otherwise null
+     *
+     * @throws GeneratorException
+     */
+    static String applyMultiSelector(final Instance inst, final String... selectors) throws
+            GeneratorException
+    {
+        StringBuilder sb = new StringBuilder();
+        boolean hasVal = false;
+        for (String selector : selectors) {
+            Matcher matcher = quoted.matcher(selector);
+            if (matcher.matches()) {
+                sb.append(matcher.group(2));
+            } else {
+                String val = applySingleSelector(inst, selector);
+                if (null != val && !"".equals(val)) {
+                    hasVal = true;
+                    sb.append(val);
+                }
+            }
+        }
+
+        return hasVal ? sb.toString() : null;
+    }
     static String applySingleSelector(final Instance inst, final String selector) throws
         GeneratorException {
         if (null != selector && !"".equals(selector) && selector.startsWith("tags/")) {

--- a/src/test/groovy/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapperSpec.groovy
+++ b/src/test/groovy/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapperSpec.groovy
@@ -1,0 +1,121 @@
+package com.dtolabs.rundeck.plugin.resources.ec2
+
+import com.amazonaws.services.ec2.model.Instance
+import com.amazonaws.services.ec2.model.InstanceState
+import com.amazonaws.services.ec2.model.InstanceStateName
+import com.amazonaws.services.ec2.model.Tag
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * @author greg
+ * @since 12/16/16
+ */
+class InstanceToNodeMapperSpec extends Specification {
+    def "single selector valid properties"() {
+        given:
+        def i = mkInstance()
+
+        when:
+        def result = InstanceToNodeMapper.applySingleSelector(i, selector)
+
+        then:
+        result == expect
+
+        where:
+        selector           | expect
+        'instanceId'       | 'aninstanceId'
+        'architecture'     | 'anarch'
+        'state.name'       | 'running'
+        'privateIpAddress' | '127.0.9.9'
+        'publicDnsName'    | null
+    }
+
+    @Unroll
+    def "single selector invalid properties #selector"() {
+        given:
+        def i = mkInstance()
+
+        when:
+        def result = InstanceToNodeMapper.applySingleSelector(i, selector)
+
+        then:
+        result == null
+        InstanceToNodeMapper.GeneratorException e = thrown()
+        e != null
+
+        where:
+        selector       | _
+        'fromtom'      | _
+        'bigglesworth' | _
+        'badapple'     | _
+    }
+
+    def "single selector tags"() {
+        given:
+        def i = mkInstance()
+
+        when:
+        def result = InstanceToNodeMapper.applySingleSelector(i, selector)
+
+        then:
+        result == expect
+
+        where:
+        selector       | expect
+        'tags/name'    | 'bob'
+        'tags/env'     | 'PROD'
+        'tags/missing' | null
+    }
+
+    def "apply selector"() {
+        given:
+        def i = mkInstance()
+        when:
+        def result = InstanceToNodeMapper.applySelector(i, selector, defVal)
+        then:
+        result == expect
+
+        where:
+        selector                       | defVal      | expect
+        'instanceId,publicDnsName'     | null        | 'aninstanceId'
+        'publicDnsName,instanceId'     | null        | 'aninstanceId'
+        'privateIpAddress,instanceId'  | null        | '127.0.9.9'
+        'instanceId,privateIpAddress'  | null        | 'aninstanceId'
+        'publicDnsName,instanceId'     | null        | 'aninstanceId'
+        'publicDnsName,privateDnsName' | null        | null
+        'publicDnsName,privateDnsName' | 'a default' | 'a default'
+    }
+
+    def "apply selector merged tags"() {
+        given:
+        def i = mkInstance()
+        when:
+        def result = InstanceToNodeMapper.applySelector(i, selector, defVal, true)
+        then:
+        result == expect
+
+        where:
+        selector                       | defVal      | expect
+        'tags/name|tags/env'           | null        | 'bob,PROD'
+        'publicDnsName|instanceId'     | null        | 'aninstanceId'
+        'privateIpAddress|instanceId'  | null        | '127.0.9.9,aninstanceId'
+        'instanceId|privateIpAddress'  | null        | 'aninstanceId,127.0.9.9'
+        'publicDnsName|instanceId'     | null        | 'aninstanceId'
+        'publicDnsName|privateDnsName' | null        | null
+        'publicDnsName|privateDnsName' | 'a default' | 'a default'
+    }
+
+    private static Instance mkInstance() {
+        Instance i = new Instance()
+        i.withTags(new Tag('name', 'bob'), new Tag('env', 'PROD'))
+        i.setInstanceId("aninstanceId")
+        i.setArchitecture("anarch")
+
+        def state = new InstanceState()
+        state.setName(InstanceStateName.Running)
+        i.setState(state)
+        i.setPrivateIpAddress('127.0.9.9')
+        return i
+    }
+}


### PR DESCRIPTION
Can be used to de-dupe node names for autoscaling groups:

    nodename.selector=tags/Name+'-'+instanceId

