### PR TITLE
Support multiple values in aws filter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,8 +63,8 @@ dependencies {
     pluginLibs group: 'stax', name: 'stax', version: '1.2.0'
     pluginLibs group: 'stax-api', name: 'stax-api', version: '1.0.1'
 
-    pluginLibs group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '1.9.0'
-    pluginLibs group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: '1.9.0'
+    pluginLibs group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '1.11.148'
+    pluginLibs group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: '1.11.148'
 
     testCompile "org.codehaus.groovy:groovy-all:2.3.7"
     testCompile "org.spockframework:spock-core:0.7-groovy-2.0"

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapper.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapper.java
@@ -180,7 +180,7 @@ class InstanceToNodeMapper {
             for (final String filterParam : getFilterParams()) {
                 final String[] x = filterParam.split("=", 2);
                 if (!"".equals(x[0]) && !"".equals(x[1])) {
-                    filters.add(new Filter(x[0]).withValues(x[1]));
+                    filters.add(new Filter(x[0]).withValues(x[1].split(",")));
                 }
             }
         }


### PR DESCRIPTION
A list of string should be passed to filter  as value. Following the same nomenclature than AWS the strings are separated by ","