### PR TITLE
Get all ec2 response pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
 - oraclejdk8
-dist: trusy
 before_cache:
 - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
 cache:

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'java'
 apply plugin: 'groovy'
 apply plugin: 'idea'
 apply plugin: 'pl.allegro.tech.build.axion-release'
-sourceCompatibility = 1.6
+sourceCompatibility = 1.8
 defaultTasks 'clean', 'build'
 ext.rundeckPluginVersion = '1.1'
 scmVersion {

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSource.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSource.java
@@ -75,6 +75,7 @@ public class EC2ResourceModelSource implements ResourceModelSource {
     Future<INodeSet> futureResult = null;
     final Properties mapping = new Properties();
     final String assumeRoleArn;
+    int pageResults;
 
     AWSCredentials credentials;
     ClientConfiguration clientConfiguration = new ClientConfiguration();;
@@ -140,6 +141,7 @@ public class EC2ResourceModelSource implements ResourceModelSource {
         this.accessKey = configuration.getProperty(EC2ResourceModelSourceFactory.ACCESS_KEY);
         this.secretKey = configuration.getProperty(EC2ResourceModelSourceFactory.SECRET_KEY);
         this.endpoint = configuration.getProperty(EC2ResourceModelSourceFactory.ENDPOINT);
+        this.pageResults = Integer.parseInt(configuration.getProperty(EC2ResourceModelSourceFactory.MAX_RESULTS));
         this.httpProxyHost = configuration.getProperty(EC2ResourceModelSourceFactory.HTTP_PROXY_HOST);
         int proxyPort = 80;
 
@@ -219,7 +221,7 @@ public class EC2ResourceModelSource implements ResourceModelSource {
         }
 
 
-        mapper = new InstanceToNodeMapper(this.credentials, mapping, clientConfiguration);
+        mapper = new InstanceToNodeMapper(this.credentials, mapping, clientConfiguration, pageResults);
         mapper.setFilterParams(params);
         mapper.setEndpoint(endpoint);
         mapper.setRunningStateOnly(runningOnly);

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSource.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSource.java
@@ -268,19 +268,15 @@ public class EC2ResourceModelSource implements ResourceModelSource {
      */
     private void checkFuture() {
         if (null != futureResult && futureResult.isDone()) {
-            getFutureValue();
+            try {
+                iNodeSet = futureResult.get();
+            } catch (InterruptedException e) {
+                logger.debug(e);
+            } catch (ExecutionException e) {
+                logger.warn("Error performing query: " + e.getMessage(), e);
+            }
+            futureResult = null;
         }
-    }
-
-    private void getFutureValue() {
-        try {
-            iNodeSet = futureResult.get();
-        } catch (InterruptedException e) {
-            logger.debug(e);
-        } catch (ExecutionException e) {
-            logger.warn("Error performing query: " + e.getMessage(), e);
-        }
-        futureResult = null;
     }
 
     /**

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSourceFactory.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSourceFactory.java
@@ -68,6 +68,7 @@ public class EC2ResourceModelSourceFactory implements ResourceModelSourceFactory
     public static final String HTTP_PROXY_PORT = "httpProxyPort";
     public static final String HTTP_PROXY_USER = "httpProxyUser";
     public static final String HTTP_PROXY_PASS = "httpProxyPass";
+    public static final String MAX_RESULTS = "pageResults";
 
     public EC2ResourceModelSourceFactory(final Framework framework) {
         this.framework = framework;
@@ -169,6 +170,9 @@ public class EC2ResourceModelSourceFactory implements ResourceModelSourceFactory
                     "Include Running state instances only. If false, all instances will be returned that match your " +
                             "filters.",
                     false, "true"))
+            .property(PropertyUtil.integer(MAX_RESULTS, "Max API Results",
+                    "Max number of reservations returned per AWS API call.",
+                    false, "100"))
 
             .build();
 

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapper.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapper.java
@@ -61,14 +61,16 @@ class InstanceToNodeMapper {
     private String endpoint;
     private boolean runningStateOnly = true;
     private Properties mapping;
+    private int maxResults;
 
     /**
      * Create with the credentials and mapping definition
      */
-    InstanceToNodeMapper(final AWSCredentials credentials, final Properties mapping, final ClientConfiguration clientConfiguration) {
+    InstanceToNodeMapper(final AWSCredentials credentials,final Properties mapping, final ClientConfiguration clientConfiguration, final int maxResults) {
         this.credentials = credentials;
         this.mapping = mapping;
         this.clientConfiguration = clientConfiguration;
+        this.maxResults = maxResults;
     }
 
     /**
@@ -89,8 +91,7 @@ class InstanceToNodeMapper {
         }
         final ArrayList<Filter> filters = buildFilters();
 
-        
-        final Set<Instance> instances = query(ec2, new DescribeInstancesRequest().withFilters(filters));
+        final Set<Instance> instances = query(ec2, new DescribeInstancesRequest().withFilters(filters).withMaxResults(maxResults));
 
         mapInstances(nodeSet, instances);
         return nodeSet;


### PR DESCRIPTION
Pages through the AWS request to ensure all instances are fetched. The query workflow has been collapsed into a single method to simplify the paging, and is run in background thread via the executor service.