### PR TITLE
Update readme.md to include pageResults config property

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,6 +49,7 @@ Here are the configuration properties:
 * `useDefaultMapping`: if "true", base all mapping definitions off the default mapping provided.
 * `mappingParams`: A set of ";" separated mapping entries
 * `mappingFile`: Path to a java properties-formatted mapping definition file.
+* `pageResults`: Max elements per page for AWS API calls - REQUIRED
 
 If you leave `accessKey` and `secretKey` blank, the EC2 IAM profile will be used.
 


### PR DESCRIPTION
upgrading from older version this plugin, the project config files, may lack this settings, resulting in generic Java Int parsing errors,
emitted from this line: https://github.com/rundeck-plugins/rundeck-ec2-nodes-plugin/blob/master/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSource.java#L146

Fixing this issue, can be done manually by editing the project config file to include:
resources.source.X.config.pageResults=100 # default settings

or by simply editing the nodes of the project directly from GUI, editing the plugin config, and saving, the page result setting is automatically added..

This readme change, along with the commit message might help others when facing this issue, or going through the configuration properties to ensure proper setup (I only managed to fix it by chance, and using both methods I mentioned..)