### PR TITLE
Add region property as alternative to endpoint

### DIFF
--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSource.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSource.java
@@ -75,6 +75,8 @@ public class EC2ResourceModelSource implements ResourceModelSource {
     int httpProxyPort = 80;
     String httpProxyUser;
     String httpProxyPass;
+
+    String region;
     String mappingParams;
     File mappingFile;
     Services services;
@@ -150,6 +152,7 @@ public class EC2ResourceModelSource implements ResourceModelSource {
     public EC2ResourceModelSource(final Properties configuration, final Services services) {
         this.accessKey = configuration.getProperty(EC2ResourceModelSourceFactory.ACCESS_KEY);
         this.secretKey = configuration.getProperty(EC2ResourceModelSourceFactory.SECRET_KEY);
+        this.region = configuration.getProperty(EC2ResourceModelSourceFactory.REGION);
         this.secretKeyStoragePath = configuration.getProperty(EC2ResourceModelSourceFactory.SECRET_KEY_STORAGE_PATH);
         this.endpoint = configuration.getProperty(EC2ResourceModelSourceFactory.ENDPOINT);
         this.pageResults = Integer.parseInt(configuration.getProperty(EC2ResourceModelSourceFactory.MAX_RESULTS));
@@ -241,6 +244,7 @@ public class EC2ResourceModelSource implements ResourceModelSource {
         mapper = new InstanceToNodeMapper(this.credentials, mapping, clientConfiguration, pageResults);
         mapper.setFilterParams(params);
         mapper.setEndpoint(endpoint);
+        mapper.setRegion(region);
         mapper.setRunningStateOnly(runningOnly);
     }
 

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSource.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSource.java
@@ -75,7 +75,6 @@ public class EC2ResourceModelSource implements ResourceModelSource {
     int httpProxyPort = 80;
     String httpProxyUser;
     String httpProxyPass;
-
     String region;
     String mappingParams;
     File mappingFile;

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSourceFactory.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSourceFactory.java
@@ -160,6 +160,9 @@ public class EC2ResourceModelSourceFactory implements ResourceModelSourceFactory
                             "Optionally use `ALL_REGIONS` to automatically pull in instances from all regions that the AWS credentials (or IAM Role) have access to.",
                     false,
                     null))
+            .property(PropertyUtil.string(REGION, "Region", "AWS EC2 region.",
+                    false,
+                    null))
             .property(PropertyUtil.string(HTTP_PROXY_HOST, "HTTP Proxy Host", "HTTP Proxy Host Name, or blank for default", false, null))
             .property(PropertyUtil.integer(HTTP_PROXY_PORT, "HTTP Proxy Port", "HTTP Proxy Port, or blank for 80", false, "80"))
             .property(PropertyUtil.string(HTTP_PROXY_USER, "HTTP Proxy User", "HTTP Proxy User Name, or blank for default", false, null))

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSourceFactory.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSourceFactory.java
@@ -62,6 +62,7 @@ public class EC2ResourceModelSourceFactory implements ResourceModelSourceFactory
     public static final String SECRET_KEY = "secretKey";
     public static final String SECRET_KEY_STORAGE_PATH = "secretKeyStoragePath";
     public static final String ROLE_ARN = "assumeRoleArn";
+    public static final String REGION = "region";
     public static final String MAPPING_FILE = "mappingFile";
     public static final String REFRESH_INTERVAL = "refreshInterval";
     public static final String SYNCHRONOUS_LOAD = "synchronousLoad";

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapper.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapper.java
@@ -145,7 +145,7 @@ class InstanceToNodeMapper {
             }
         }
         else if(region != null){
-            ec2.setRegion(com.amazonaws.regions.Region.getRegion(Regions.fromName(region)));
+            ec2.setEndpoint("https://ec2." + region + ".amazonaws.com");
         }
         else{
             zones = ec2.describeAvailabilityZones();

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapper.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapper.java
@@ -25,6 +25,8 @@ package com.dtolabs.rundeck.plugin.resources.ec2;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.regions.RegionImpl;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.model.*;
 import com.dtolabs.rundeck.core.common.INodeEntry;
@@ -54,6 +56,7 @@ class InstanceToNodeMapper {
     private ExecutorService executorService = Executors.newSingleThreadExecutor();
     private ArrayList<String> filterParams;
     private String endpoint;
+    private String region;
     private boolean runningStateOnly = true;
     private Properties mapping;
     private int maxResults;
@@ -140,6 +143,9 @@ class InstanceToNodeMapper {
                     Thread.currentThread().interrupt();
                 }
             }
+        }
+        else if(region != null){
+            ec2.setRegion(com.amazonaws.regions.Region.getRegion(Regions.fromName(region)));
         }
         else{
             zones = ec2.describeAvailabilityZones();
@@ -494,6 +500,10 @@ class InstanceToNodeMapper {
      */
     public void setEndpoint(final String endpoint) {
         this.endpoint = endpoint;
+    }
+
+    public void setRegion(final String region) {
+        this.region = region;
     }
 
     public Properties getMapping() {


### PR DESCRIPTION
Added a region property. endpoint still takes precedence but if a region is set in the plugin group or the plugin level then it will use that