### PR TITLE
RUN-2824: Respect the AWS_STS_REGIONAL_ENDPOINTS parameter

### DIFF
--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSource.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSource.java
@@ -25,7 +25,8 @@ package com.dtolabs.rundeck.plugin.resources.ec2;
 
 import com.amazonaws.auth.*;
 import com.amazonaws.ClientConfiguration;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.amazonaws.services.securitytoken.model.*;
 import com.dtolabs.rundeck.core.common.*;
 import com.dtolabs.rundeck.core.plugins.configuration.ConfigurationException;
@@ -248,14 +249,18 @@ public class EC2ResourceModelSource implements ResourceModelSource {
     }
 
     private AWSCredentials createAwsCredentials(AWSCredentialsProvider provider, String assumeRoleArn, String externalId) {
-        AWSSecurityTokenServiceClient sts_client;
+        AWSSecurityTokenService sts_client;
 
         if (provider != null) {
-            sts_client = new AWSSecurityTokenServiceClient(provider, clientConfiguration);
+            sts_client = AWSSecurityTokenServiceClientBuilder.standard()
+                    .withCredentials(provider)
+                    .withClientConfiguration(clientConfiguration)
+                    .build();
         } else {
-            sts_client = new AWSSecurityTokenServiceClient(clientConfiguration);
+            sts_client = AWSSecurityTokenServiceClientBuilder.standard()
+                    .withClientConfiguration(clientConfiguration)
+                    .build();
         }
-        //        sts_client.setEndpoint("sts-endpoint.amazonaws.com");
         AssumeRoleRequest assumeRoleRequest = new AssumeRoleRequest();
         assumeRoleRequest.setRoleArn(assumeRoleArn);
         if(externalId!=null){


### PR DESCRIPTION
Closes #110 

This modification allows the use of STS regionalized endpoints by specifying the AWS_STS_REGIONAL_ENDPOINTS=regional environment variable.

AWS STS has global and per-region endpoints.
https://docs.aws.amazon.com/sdkref/latest/guide/feature-sts-regionalized-endpoints.html

AWS recommends STS regionalized endpoints (AWS_STS_REGIONAL_ENDPOINTS=regional), but defaults to STS global endpoints (AWS_STS_REGIONAL_ENDPOINTS=legacy ).

On August 29, 2024, an AWS STS failure occurred and requests using the STS global endpoints failed. This failure did not affect requests using STS Regionalized endpoints.

![image](https://github.com/user-attachments/assets/ef62a7c3-4d58-47e0-be22-b6ebe0970ffe)


The current implementation uses AWS SecurityTokenServiceClient when creating sts clients. This method is deprecated and does not read the STS endpoint configuration.
https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/securitytoken/AWSSecurityTokenServiceClient.html#AWSSecurityTokenServiceClient-com.amazonaws.auth.AWSCredentialsProvider-com.amazonaws.ClientConfiguration-

Instead, the AWSsecurityTokenServiceClientBuilder is used to allow the STS endpoint settings to be respected.