### PR TITLE
RUN-2285: Update aws sdk version and exclude httpcilent from build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,7 +26,7 @@ jobs:
         id: get_version
         run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
       - name: Upload sshj-plugin jar
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4
         with:
           # Artifact name
           name: Grails-Plugin-${{ steps.get_version.outputs.VERSION }}

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,10 @@ buildscript {
 
 plugins {
     id 'pl.allegro.tech.build.axion-release' version '1.13.4'
+    id 'maven-publish'
 }
+
+group = 'com.github.rundeck-plugins'
 
 apply plugin: 'java'
 apply plugin: 'groovy'
@@ -106,3 +109,12 @@ jar {
 
 //set jar task to depend on copyToLib
 jar.dependsOn(copyToLib)
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId = 'rundeck-ec2-nodes-plugin'
+            from components.java
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -36,10 +36,11 @@ project.version = scmVersion.version
 
 configurations{
     //declare custom pluginLibs configuration to include only libs for this plugin
-    pluginLibs
+    pluginLibs {
+    }
 
     //declare compile to extend from pluginLibs so it inherits the dependencies
-    implementation{
+    implementation {
         extendsFrom pluginLibs
     }
 }
@@ -49,23 +50,24 @@ repositories {
 }
 dependencies {
     implementation "org.slf4j:slf4j-api:1.7.36"
-    implementation (group: 'org.rundeck', name: 'rundeck-core', version: '3.4.0-20210614') {
+    implementation (group: 'org.rundeck', name: 'rundeck-core', version: '4.0.0-20220322') {
         exclude group: "com.google.guava"
     }
-    implementation "com.amazonaws:aws-java-sdk-core:1.11.743"
-    implementation "com.amazonaws:aws-java-sdk-sts:1.11.743"
+    implementation "com.amazonaws:aws-java-sdk-core:${awsSdkVersion}"
+    implementation "com.amazonaws:aws-java-sdk-sts:${awsSdkVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.10.5.1"
     implementation group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
 
     pluginLibs group: 'stax', name: 'stax', version: '1.2.0'
     pluginLibs group: 'javax.xml.stream', name: 'stax-api', version: '1.0'
 
-    pluginLibs (group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '1.11.743') {
+    pluginLibs (group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: "${awsSdkVersion}") {
+        exclude group: "org.apache.httpcomponents", module: "httpclient"
         exclude group: "com.fasterxml.jackson.core"
         exclude group: "com.fasterxml.jackson.dataformat"
     }
-
-    pluginLibs (group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: '1.11.743') {
+    pluginLibs (group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: "${awsSdkVersion}") {
+        exclude group: "org.apache.httpcomponents", module: "httpclient"
         exclude group: "com.fasterxml.jackson.core"
         exclude group: "com.fasterxml.jackson.dataformat"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+awsSdkVersion=1.12.770


### PR DESCRIPTION
- Updates the version of AWS SDK to `1.12.770`.
- Excludes apache httpclient library from build bundle, as its included in rundeck.