### PR TITLE
RUN-3179: Update use of AWS SDK

### DIFF
--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSourceFactory.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSourceFactory.java
@@ -93,7 +93,10 @@ public class EC2ResourceModelSourceFactory implements ResourceModelSourceFactory
         return null;
     }
 
-    static Description DESC = DescriptionBuilder.builder()
+    public static final Map<String, Object> PROXY_OPTIONS = Map.of(
+            StringRenderingConstants.GROUP_NAME, "Proxy",
+            StringRenderingConstants.GROUPING, "secondary"
+    );
 
     public static final Map<String, Object> PASSWORD_OPTIONS = Collections.singletonMap(StringRenderingConstants.DISPLAY_TYPE_KEY, StringRenderingConstants.DisplayType.PASSWORD);
 
@@ -173,9 +176,11 @@ public class EC2ResourceModelSourceFactory implements ResourceModelSourceFactory
             .property(PropertyUtil.string(REGION, "Region", "AWS EC2 region.",
                     false,
                     null))
-            .property(PropertyUtil.string(HTTP_PROXY_HOST, "HTTP Proxy Host", "HTTP Proxy Host Name, or blank for default", false, null))
-            .property(PropertyUtil.integer(HTTP_PROXY_PORT, "HTTP Proxy Port", "HTTP Proxy Port, or blank for 80", false, "80"))
-            .property(PropertyUtil.string(HTTP_PROXY_USER, "HTTP Proxy User", "HTTP Proxy User Name, or blank for default", false, null))
+            .property(PropertyUtil.string(HTTP_PROXY_HOST, "HTTP Proxy Host", "HTTP Proxy Host Name, or blank for default", false, null, null,null,
+                    PROXY_OPTIONS
+            ))
+            .property(PropertyUtil.integer(HTTP_PROXY_PORT, "HTTP Proxy Port", "HTTP Proxy Port, or blank for 80", false, "80",null,null,PROXY_OPTIONS))
+            .property(PropertyUtil.string(HTTP_PROXY_USER, "HTTP Proxy User", "HTTP Proxy User Name, or blank for default", false, null,null,null,PROXY_OPTIONS))
             .property(
                     PropertyUtil.string(
                             HTTP_PROXY_PASS,
@@ -185,7 +190,11 @@ public class EC2ResourceModelSourceFactory implements ResourceModelSourceFactory
                             null,
                             null,
                             null,
-                            Collections.singletonMap("displayType", (Object) StringRenderingConstants.DisplayType.PASSWORD)
+                            Map.of(
+                                    StringRenderingConstants.GROUP_NAME, "Proxy",
+                                    StringRenderingConstants.GROUPING, "secondary",
+                                    StringRenderingConstants.DISPLAY_TYPE_KEY, StringRenderingConstants.DisplayType.PASSWORD
+                            )
                     )
             )
             .property(PropertyUtil.string(MAPPING_PARAMS, "Mapping Params",

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSourceFactory.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSourceFactory.java
@@ -203,13 +203,11 @@ public class EC2ResourceModelSourceFactory implements ResourceModelSourceFactory
                             "separated by \";\"",
                     false, null))
             .property(PropertyUtil.string(MAPPING_FILE, "Mapping File", "Property mapping File", false, null,
-                    new PropertyValidator() {
-                        public boolean isValid(final String s) throws ValidationException {
-                            if (!new File(s).isFile()) {
-                                throw new ValidationException("File does not exist: " + s);
-                            }
-                            return true;
+                    s -> {
+                        if (!new File(s).isFile()) {
+                            throw new ValidationException("File does not exist: " + s);
                         }
+                        return true;
                     }))
             .property(PropertyUtil.bool(USE_DEFAULT_MAPPING, "Use Default Mapping",
                     "Start with default mapping definition. (Defaults will automatically be used if no others are " +

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSourceFactory.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSourceFactory.java
@@ -77,8 +77,10 @@ public class EC2ResourceModelSourceFactory implements ResourceModelSourceFactory
     public static final String HTTP_PROXY_PASS = "httpProxyPass";
     public static final String MAX_RESULTS = "pageResults";
 
+    public EC2ResourceModelSourceFactory() {
+
+    }
     public EC2ResourceModelSourceFactory(final Framework framework) {
-        this.framework = framework;
     }
 
     public ResourceModelSource createResourceModelSource(Services services, final Properties configuration) throws ConfigurationException {
@@ -92,6 +94,10 @@ public class EC2ResourceModelSourceFactory implements ResourceModelSourceFactory
     }
 
     static Description DESC = DescriptionBuilder.builder()
+
+    public static final Map<String, Object> PASSWORD_OPTIONS = Collections.singletonMap(StringRenderingConstants.DISPLAY_TYPE_KEY, StringRenderingConstants.DisplayType.PASSWORD);
+
+    public static final Description DESC = DescriptionBuilder.builder()
             .name(PROVIDER_NAME)
             .title("AWS EC2 Resources")
             .description("Produces nodes from AWS EC2")
@@ -106,7 +112,7 @@ public class EC2ResourceModelSourceFactory implements ResourceModelSourceFactory
                             null,
                             null,
                             null,
-                            Collections.singletonMap("displayType", (Object) StringRenderingConstants.DisplayType.PASSWORD)
+                            PASSWORD_OPTIONS
                     )
             )
             .property(
@@ -118,11 +124,11 @@ public class EC2ResourceModelSourceFactory implements ResourceModelSourceFactory
                             null,
                             null,
                             null,
-                            new HashMap<String, Object>(){{
-                                put(StringRenderingConstants.SELECTION_ACCESSOR_KEY,StringRenderingConstants.SelectionAccessor.STORAGE_PATH);
-                                put(StringRenderingConstants.STORAGE_PATH_ROOT_KEY,"keys");
-                                put(StringRenderingConstants.STORAGE_FILE_META_FILTER_KEY, "Rundeck-data-type=password");
-                            }}
+                            Map.of(
+                                StringRenderingConstants.SELECTION_ACCESSOR_KEY, StringRenderingConstants.SelectionAccessor.STORAGE_PATH,
+                                StringRenderingConstants.STORAGE_PATH_ROOT_KEY, "keys",
+                                StringRenderingConstants.STORAGE_FILE_META_FILTER_KEY, "Rundeck-data-type=password"
+                            )
                     )
             )
             .property(

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2Supplier.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2Supplier.java
@@ -1,0 +1,31 @@
+package com.dtolabs.rundeck.plugin.resources.ec2;
+
+import com.amazonaws.services.ec2.AmazonEC2;
+
+/**
+ * Interface for supplying AmazonEC2 clients
+ */
+public interface EC2Supplier {
+    /**
+     * Return an AmazonEC2 client for the default region
+     *
+     * @return AmazonEC2 client
+     */
+    AmazonEC2 getEC2ForDefaultRegion();
+
+    /**
+     * Return an AmazonEC2 client for the specified region
+     *
+     * @param region region name
+     * @return AmazonEC2 client
+     */
+    AmazonEC2 getEC2ForRegion(String region);
+
+    /**
+     * Return an AmazonEC2 client for the specified endpoint
+     *
+     * @param endpoint endpoint URL
+     * @return AmazonEC2 client
+     */
+    AmazonEC2 getEC2ForEndpoint(String endpoint);
+}

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2SupplierImpl.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2SupplierImpl.java
@@ -1,0 +1,72 @@
+package com.dtolabs.rundeck.plugin.resources.ec2;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
+
+
+/**
+ * Implementation of EC2Supplier, uses the AWS SDK to create AmazonEC2 clients via the AmazonEC2ClientBuilder
+ */
+public class EC2SupplierImpl implements EC2Supplier {
+    final private AWSCredentials credentials;
+    final private ClientConfiguration clientConfiguration;
+    final private Region defaultRegion;
+
+    /**
+     * Create an instance with the specified credentials and client configuration
+     *
+     * @param credentials         AWS credentials
+     * @param clientConfiguration client configuration
+     * @param region              default region
+     */
+    public EC2SupplierImpl(AWSCredentials credentials, ClientConfiguration clientConfiguration, Region region) {
+        this.credentials = credentials;
+        this.clientConfiguration = clientConfiguration;
+        this.defaultRegion = region;
+    }
+
+    @Override
+    public AmazonEC2 getEC2ForDefaultRegion() {
+        return getEC2ForRegion(null);
+    }
+
+    /**
+     * Return an AmazonEC2 client for the specified region, if the region is null, the default region is used
+     *
+     * @param region region name
+     * @return AmazonEC2 client
+     */
+    @Override
+    public AmazonEC2 getEC2ForRegion(String region) {
+        if (null == region) {
+            region = defaultRegion.getName();
+        }
+        AmazonEC2ClientBuilder builder = AmazonEC2ClientBuilder.standard().withRegion(region).withClientConfiguration(clientConfiguration);
+        if (null != credentials) {
+            builder.withCredentials(new AWSStaticCredentialsProvider(credentials));
+        }
+        return builder.build();
+    }
+
+    @Override
+    public AmazonEC2 getEC2ForEndpoint(String endpoint) {
+        if (null == endpoint) {
+            return getEC2ForDefaultRegion();
+        }
+        AwsClientBuilder.EndpointConfiguration endpointConfiguration = new AwsClientBuilder.EndpointConfiguration(endpoint, null);
+        AmazonEC2ClientBuilder amazonEC2ClientBuilder = AmazonEC2ClientBuilder.standard().withEndpointConfiguration(endpointConfiguration);
+        if (null != credentials) {
+            amazonEC2ClientBuilder.withCredentials(new AWSStaticCredentialsProvider(credentials));
+        }
+        if (null != clientConfiguration) {
+            amazonEC2ClientBuilder.withClientConfiguration(clientConfiguration);
+        }
+        return amazonEC2ClientBuilder.build();
+    }
+}

--- a/src/test/groovy/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSourceSpec.groovy
+++ b/src/test/groovy/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSourceSpec.groovy
@@ -41,14 +41,14 @@ class EC2ResourceModelSourceSpec extends Specification {
         failingConfig.setProperty(EC2ResourceModelSourceFactory.SECRET_KEY_STORAGE_PATH, badPath)
 
         // Create objects using actual ResourceModelSource and Factory
-        def workingRms = ec2ResourceModelSource(serviceWithGoodPass, workingConfig)
-        def failingRms = ec2ResourceModelSource(serviceWithBadPass, failingConfig)
+        EC2ResourceModelSource workingRms = ec2ResourceModelSource(serviceWithGoodPass, workingConfig)
+        EC2ResourceModelSource failingRms = ec2ResourceModelSource(serviceWithBadPass, failingConfig)
 
         when: "we check the access keys of the resource model source objects"
         // Instead of using getNodes, which would all be highly mocked, just check that we got as far as setting
         // proper credentials right before the point we would call to AWS
-        def workingRmsPass = workingRms.credentials.getAWSSecretKey()
-        def failingRmsPass = failingRms.credentials.getAWSSecretKey()
+        def workingRmsPass = workingRms.createCredentials().getAWSSecretKey()
+        def failingRmsPass = failingRms.createCredentials().getAWSSecretKey()
 
         then: "we see that the proper keys from the key storage or the inline key have been derived"
         workingRmsPass == validSecretKey


### PR DESCRIPTION
* remove use of deprecated AWS SDK classes
* use builders for EC2 clients
* some cleanup and refactoring
* clarify endpoint vs region usage

UI Cleanup:
* move Proxy properties into a secondary grouping