### PR TITLE
RUN-3100 allow get node instances data for each region in parallel

### DIFF
--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSource.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSource.java
@@ -82,6 +82,7 @@ public class EC2ResourceModelSource implements ResourceModelSource {
     boolean useDefaultMapping = true;
     boolean runningOnly = false;
     boolean queryAsync = true;
+    boolean queryNodeInstancesInParallel = false;
     Future<INodeSet> futureResult = null;
     final Properties mapping = new Properties();
     final String assumeRoleArn;
@@ -219,6 +220,7 @@ public class EC2ResourceModelSource implements ResourceModelSource {
         }
         queryAsync = !("true".equals(configuration.getProperty(SYNCHRONOUS_LOAD)) || refreshInterval <= 0);
 
+        this.queryNodeInstancesInParallel = Boolean.parseBoolean(configuration.getProperty(EC2ResourceModelSourceFactory.QUERY_NODE_INSTANCES_IN_PARALLEL, "false"));
         initialize();
     }
 
@@ -296,12 +298,12 @@ public class EC2ResourceModelSource implements ResourceModelSource {
          */
         if (lastRefresh > 0 && queryAsync && null == futureResult) {
             futureResult = executor.submit(() -> {
-                return mapper.performQuery();
+                return mapper.performQuery(queryNodeInstancesInParallel);
             });
             lastRefresh = System.currentTimeMillis();
         } else if (!queryAsync || lastRefresh < 1) {
             //always perform synchronous query the first time
-            iNodeSet = mapper.performQuery();
+            iNodeSet = mapper.performQuery(queryNodeInstancesInParallel);
             lastRefresh = System.currentTimeMillis();
         }
 

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSourceFactory.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2ResourceModelSourceFactory.java
@@ -71,6 +71,7 @@ public class EC2ResourceModelSourceFactory implements ResourceModelSourceFactory
     public static final String REFRESH_INTERVAL = "refreshInterval";
     public static final String SYNCHRONOUS_LOAD = "synchronousLoad";
     public static final String USE_DEFAULT_MAPPING = "useDefaultMapping";
+    public static final String QUERY_NODE_INSTANCES_IN_PARALLEL = "queryNodeInstancesInParallel";
     public static final String HTTP_PROXY_HOST = "httpProxyHost";
     public static final String HTTP_PROXY_PORT = "httpProxyPort";
     public static final String HTTP_PROXY_USER = "httpProxyUser";
@@ -207,6 +208,9 @@ public class EC2ResourceModelSourceFactory implements ResourceModelSourceFactory
             .property(PropertyUtil.integer(MAX_RESULTS, "Max API Results",
                     "Max number of reservations returned per AWS API call.",
                     false, "100"))
+            .property(PropertyUtil.bool(QUERY_NODE_INSTANCES_IN_PARALLEL, "Query Node Instances in Parallel",
+                    "Query node instances in parallel. If false, instances will be queried one at a time.",
+                    false, "false"))
 
             .build();
 

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapper.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapper.java
@@ -190,12 +190,6 @@ class InstanceToNodeMapper {
             allInstances.addAll(newInstances);
         }
 
-        try {
-            Thread.sleep(100);
-        } catch (InterruptedException ex) {
-            Thread.currentThread().interrupt();
-        }
-
         return allInstances;
     }
 

--- a/src/test/groovy/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapperSpec.groovy
+++ b/src/test/groovy/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapperSpec.groovy
@@ -325,7 +325,7 @@ class InstanceToNodeMapperSpec extends Specification {
         def mapper = new InstanceToNodeMapper(supplier, mapping, pageResults);
         mapper.setEndpoint(endpoints.join(', '))
         when:
-        def instances = mapper.performQuery()
+        def instances = mapper.performQuery(false)
         then:
         instances!=null
         instances.getNode("aninstanceId").getAttributes().containsKey("region")
@@ -384,7 +384,7 @@ class InstanceToNodeMapperSpec extends Specification {
         def mapper = new InstanceToNodeMapper(supplier, mapping, pageResults);
         mapper.setEndpoint(endpoint)
         when:
-        def instances = mapper.performQuery()
+        def instances = mapper.performQuery(false)
         then:
         instances!=null
         instances.getNode("aninstanceId").getAttributes().containsKey("region")

--- a/src/test/groovy/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapperSpec.groovy
+++ b/src/test/groovy/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapperSpec.groovy
@@ -190,7 +190,7 @@ class InstanceToNodeMapperSpec extends Specification {
         mapper.setEndpoint("us-west-1")
 
         when:
-        def instances = mapper.performQuery()
+        def instances = mapper.performQuery(false)
         then:
         instances!=null
         instances.getNode("aninstanceId").getAttributes().containsKey(expected)
@@ -230,7 +230,7 @@ class InstanceToNodeMapperSpec extends Specification {
         def mapper = new InstanceToNodeMapper(ec2, credentials, mapping, clientConfiguration, pageResults);
         mapper.setEndpoint("us-west-1")
         when:
-        def instances = mapper.performQuery()
+        def instances = mapper.performQuery(false)
         then:
         instances!=null
         0*ec2.describeImages(_)
@@ -270,7 +270,7 @@ class InstanceToNodeMapperSpec extends Specification {
         def mapper = new InstanceToNodeMapper(ec2, credentials, mapping, clientConfiguration, pageResults);
         mapper.setEndpoint("us-east-1")
         when:
-        def instances = mapper.performQuery()
+        def instances = mapper.performQuery(false)
         then:
         instances!=null
         instances.getNode("aninstanceId").getAttributes().containsKey("region")


### PR DESCRIPTION
This PR add another property to enable/disable the requests to EC2 and get node instances in parallel for each region. It should improve the performance when using a large number of regions