### PR TITLE
RUN-3329: Migrate to central portal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,10 @@ jar.dependsOn(copyToLib)
 nexusPublishing {
     packageGroup = 'org.rundeck.plugins'
     repositories {
-        sonatype()
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+        }
     }
 }
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is maintenance since sonatype legacy system will stop working on June 30th, 2025.

**Describe the solution you've implemented**
URL's has been changed as shown on this doc
[https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration](url)