### PR TITLE
RUN-3513: Fix CVE-2025-48734: Upgrade commons-beanutils to 1.11.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 axionRelease = "1.18.17"
 awsSdk = "1.12.780"
 cglib = "3.3.0"
-commonsBeanutils = "1.10.1"
+commonsBeanutils = "1.11.0"
 groovy = "3.0.23"
 jacksonDatabind = "2.18.2"
 nexusPublish = "2.0.0"


### PR DESCRIPTION
**Summary**
Upgrades commons-beanutils dependency from version 1.10.1 to 1.11.0 to address security vulnerability CVE-2025-48734.

**Changes**
Updated commonsBeanutils version in [libs.versions.toml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) from 1.10.1 to 1.11.0
Security Impact
Resolves CVE-2025-48734 vulnerability in commons-beanutils
No breaking changes expected as this is a patch-level security update
Testing
Build passes with new dependency version
No API changes in commons-beanutils that would affect plugin functionality