### PR TITLE
[RUN-4638] Migrate publishing from Maven Central to PackageCloud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: Upload Release Asset
     runs-on: ubuntu-latest
+    env:
+      PKGCLD_REPO_URL: ${{ vars.PKGCLD_REPO_URL }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -35,10 +37,38 @@ jobs:
             build/libs/rundeck-ec2-nodes-plugin-${{ steps.get_version.outputs.VERSION }}.jar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish to Maven Central
-        run: ./gradlew -PsigningKey=${SIGNING_KEY_B64} -PsigningPassword=${SIGNING_PASSWORD} -PsonatypeUsername=${SONATYPE_USERNAME} -PsonatypePassword=${SONATYPE_PASSWORD} publishToSonatype closeAndReleaseSonatypeStagingRepository
+      - name: Publish to PackageCloud
+        run: |
+          if [ -z "$PKGCLD_WRITE_TOKEN" ]; then
+            echo "::error::PKGCLD_WRITE_TOKEN must be set to publish to PackageCloud"
+            exit 1
+          fi
+          ./gradlew publishAllPublicationsToPackageCloudRepository
         env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}
+      - name: Sign and upload GPG signatures to PackageCloud
+        run: |
+          set -e
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          BASE_URL="${PKGCLD_REPO_URL:-https://packagecloud.io/pagerduty/rundeck-plugins/maven2}/org/rundeck/plugins/rundeck-ec2-nodes-plugin/${VERSION}"
+
+          echo "$SIGNING_KEY_B64" | base64 -d | gpg --batch --yes --import
+          KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/ {print $5; exit}')
+
+          sign_and_upload() {
+            local FILE="$1"
+            local REMOTE_NAME="$2"
+            gpg --batch --yes --pinentry-mode loopback --passphrase "$SIGNING_PASSWORD" --default-key "$KEY_ID" --detach-sign --armor "$FILE"
+            curl -sf -H "Authorization: Bearer ${PKGCLD_WRITE_TOKEN}" \
+              -X PUT --data-binary "@${FILE}.asc" \
+              "${BASE_URL}/${REMOTE_NAME}.asc"
+          }
+
+          sign_and_upload "build/libs/rundeck-ec2-nodes-plugin-${VERSION}.jar" "rundeck-ec2-nodes-plugin-${VERSION}.jar"
+          sign_and_upload "build/libs/rundeck-ec2-nodes-plugin-${VERSION}-sources.jar" "rundeck-ec2-nodes-plugin-${VERSION}-sources.jar"
+          sign_and_upload "build/libs/rundeck-ec2-nodes-plugin-${VERSION}-javadoc.jar" "rundeck-ec2-nodes-plugin-${VERSION}-javadoc.jar"
+          sign_and_upload "build/publications/rundeck-ec2-nodes-plugin/pom-default.xml" "rundeck-ec2-nodes-plugin-${VERSION}.pom"
+        env:
           SIGNING_KEY_B64: ${{ secrets.SIGNING_KEY_B64 }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ plugins {
     id 'groovy'
     id 'idea'
     alias(libs.plugins.axionRelease)
-    alias(libs.plugins.nexusPublish)
 }
 
 group = 'org.rundeck.plugins'
@@ -149,24 +148,15 @@ test {
 //set jar task to depend on copyToLib
 jar.dependsOn(copyToLib)
 
-nexusPublishing {
-    packageGroup = 'org.rundeck.plugins'
-    repositories {
-        sonatype {
-            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
-        }
-    }
-}
-
 apply from: "${rootDir}/gradle/publishing.gradle"
 
-// Add PackageCloud repository
+def pkgcldRepoUrl = (System.getenv("PKGCLD_REPO_URL") ?: "https://packagecloud.io/pagerduty/rundeck-plugins/maven2").trim()
+
 publishing {
     repositories {
         maven {
-            name = "PackageCloudTest"
-            url = uri("https://packagecloud.io/pagerduty/rundeckpro-test/maven2")
+            name = "PackageCloud"
+            url = uri(pkgcldRepoUrl)
             authentication {
                 header(HttpHeaderAuthentication)
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,6 @@ cglib = "3.3.0"
 commonsBeanutils = "1.11.0"
 groovy = "4.0.32"
 jacksonDatabind = "2.22.1"
-nexusPublish = "2.0.0"
 objenesis = "3.4"
 rundeckCore = "6.1.0-SNAPSHOT"
 slf4j = "2.0.18"
@@ -32,4 +31,3 @@ testLibs = ["groovyAll", "spockCore", "cglibNodep", "objenesis"]
 
 [plugins]
 axionRelease = { id = "pl.allegro.tech.build.axion-release", version.ref = "axionRelease" }
-nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublish" }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -6,17 +6,8 @@
  * githubSlug = Github slug e.g. 'rundeck/rundeck-cli'
  * developers = [ [id:'id', name:'name', email: 'email' ] ] list of developers
  *
- * Define project properties to sign and publish when invoking publish task:
- *
- *     ./gradlew \
- *     -PsigningKey="base64 encoded gpg key" \
- *     -PsigningPassword="password for key" \
- *     -PsonatypeUsername="sonatype token user" \
- *     -PsonatypePassword="sonatype token password" \
- *     publishToSonatype closeAndReleaseSonatypeStagingRepository
  */
 apply plugin: 'maven-publish'
-apply plugin: 'signing'
 
 publishing {
     publications {
@@ -54,17 +45,5 @@ publishing {
             }
 
         }
-    }
-}
-def base64Decode = { String prop ->
-    project.findProperty(prop) ?
-            new String(Base64.getDecoder().decode(project.findProperty(prop).toString())).trim() :
-            null
-}
-
-if (project.hasProperty('signingKey') && project.hasProperty('signingPassword')) {
-    signing {
-        useInMemoryPgpKeys(base64Decode("signingKey"), project.signingPassword)
-        sign(publishing.publications)
     }
 }


### PR DESCRIPTION
## Jira ticket

[RUN-4638](https://pagerduty.atlassian.net/browse/RUN-4638) (subtask of [RUN-4570](https://pagerduty.atlassian.net/browse/RUN-4570))

## Description

Migrate `rundeck-ec2-nodes-plugin` publishing from Maven Central (Sonatype) to PackageCloud, applying the same design already validated on [rundeck-plugins/sshj-plugin#136](https://github.com/rundeck-plugins/sshj-plugin/pull/136) and the other already-migrated `rundeck-plugins` repos. Part of the RUN-4570 Maven Central publishing limits resolution — plugins account for the bulk of the file/release count on Maven Central, but no external project depends on them as Maven dependencies.

- Removed `nexusPublish`/`nexusPublishing` (version-catalog form: dropped the `alias(libs.plugins.nexusPublish)` plugin and its `nexusPublish` entries in `gradle/libs.versions.toml`).
- Point the PackageCloud maven repo at the configurable `PKGCLD_REPO_URL` env var (with a fallback to the real `rundeck-plugins` repo), replacing the half-migrated `PackageCloudTest` block that pointed at `rundeckpro-test` (this repo had it tacked onto `build.gradle` directly, after the `apply from: gradle/publishing.gradle` line, rather than inside `publishing.gradle` itself).
- Dropped Gradle-side GPG signing (`sign(publishing.publications)`): PackageCloud's Maven endpoint rejects the checksum Gradle auto-generates for `.asc` signature files (422 Unprocessable Entity). Sign and upload via `gpg` CLI + `curl` instead, directly in `release.yml` — the same mechanism validated end-to-end on `sshj-plugin`.
- `release.yml`: replaced the "Publish to Maven Central" step with "Publish to PackageCloud" + a "Sign and upload GPG signatures" step.

## Testing instructions

- Merge this PR.
- Tag a version to trigger the release workflow.
- Verify the artifact, sources jar, javadoc jar, and their `.asc` signatures land under `org/rundeck/plugins/rundeck-ec2-nodes-plugin/<version>/` on PackageCloud.
- Verify `./gradlew build` still succeeds without `PKGCLD_REPO_URL` set.
