### PR TITLE
[RUN-4795] Fix NPE when Endpoint=ALL_REGIONS on aws-ec2 resource source

### DIFF
--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2SupplierImpl.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2SupplierImpl.java
@@ -70,7 +70,8 @@ public class EC2SupplierImpl implements EC2Supplier {
     }
 
     private static String normalizeEndpoint(String endpoint) {
-        return endpoint.contains("://") ? endpoint : "https://" + endpoint;
+        String trimmed = endpoint.trim();
+        return trimmed.matches("^[a-zA-Z][a-zA-Z0-9+\\-.]*://.*") ? trimmed : "https://" + trimmed;
     }
 
     private void applyCommon(Ec2ClientBuilder builder) {

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2SupplierImpl.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/ec2/EC2SupplierImpl.java
@@ -54,14 +54,23 @@ public class EC2SupplierImpl implements EC2Supplier {
         if (null == endpoint) {
             return getEC2ForDefaultRegion();
         }
+        // AWS's DescribeRegions API (used by the ALL_REGIONS endpoint option) returns bare
+        // hostnames with no URI scheme (e.g. "ec2.us-west-1.amazonaws.com"). URI.create() does
+        // not reject that, but AWS SDK v2's endpointOverride() requires a scheme, so normalize
+        // before it's used for both region derivation and the client endpoint override.
+        String normalizedEndpoint = normalizeEndpoint(endpoint);
         // AWS SDK v2 requires a signing region even when overriding the endpoint, so derive
         // it from the endpoint host (e.g. https://ec2.us-west-1.amazonaws.com -> us-west-1).
-        Region signingRegion = regionFromEndpoint(endpoint);
+        Region signingRegion = regionFromEndpoint(normalizedEndpoint);
         Ec2ClientBuilder builder = Ec2Client.builder()
                 .region(signingRegion)
-                .endpointOverride(URI.create(endpoint));
+                .endpointOverride(URI.create(normalizedEndpoint));
         applyCommon(builder);
         return builder.build();
+    }
+
+    private static String normalizeEndpoint(String endpoint) {
+        return endpoint.contains("://") ? endpoint : "https://" + endpoint;
     }
 
     private void applyCommon(Ec2ClientBuilder builder) {

--- a/src/test/groovy/com/dtolabs/rundeck/plugin/resources/ec2/EC2SupplierImplSpec.groovy
+++ b/src/test/groovy/com/dtolabs/rundeck/plugin/resources/ec2/EC2SupplierImplSpec.groovy
@@ -28,6 +28,8 @@ class EC2SupplierImplSpec extends Specification {
         noExceptionThrown()
         client != null
 
+        cleanup:
+        client?.close()
         where:
         endpoint << [
                 'ec2.us-west-1.amazonaws.com',           // bare hostname, as returned by AWS DescribeRegions (ALL_REGIONS)

--- a/src/test/groovy/com/dtolabs/rundeck/plugin/resources/ec2/EC2SupplierImplSpec.groovy
+++ b/src/test/groovy/com/dtolabs/rundeck/plugin/resources/ec2/EC2SupplierImplSpec.groovy
@@ -1,0 +1,37 @@
+package com.dtolabs.rundeck.plugin.resources.ec2
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.ec2.Ec2Client
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Regression coverage for RUN-4795: AWS's DescribeRegions API (used by the ALL_REGIONS
+ * endpoint option) returns bare hostnames with no URI scheme, which used to reach
+ * Ec2ClientBuilder#endpointOverride() unmodified and throw:
+ * "NullPointerException: The URI scheme of endpointOverride must not be null."
+ */
+class EC2SupplierImplSpec extends Specification {
+
+    def credentials = AwsBasicCredentials.create("AKIAEXAMPLE", "secretExampleKey")
+
+    @Unroll
+    def "getEC2ForEndpoint builds a client for endpoint #endpoint"() {
+        given:
+        def supplier = new EC2SupplierImpl(credentials, null, Region.US_EAST_1)
+
+        when:
+        Ec2Client client = supplier.getEC2ForEndpoint(endpoint)
+
+        then:
+        noExceptionThrown()
+        client != null
+
+        where:
+        endpoint << [
+                'ec2.us-west-1.amazonaws.com',           // bare hostname, as returned by AWS DescribeRegions (ALL_REGIONS)
+                'https://ec2.us-west-1.amazonaws.com',   // fully-qualified URL, as required for the documented comma-separated endpoint list
+        ]
+    }
+}

--- a/src/test/groovy/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapperSpec.groovy
+++ b/src/test/groovy/com/dtolabs/rundeck/plugin/resources/ec2/InstanceToNodeMapperSpec.groovy
@@ -321,9 +321,11 @@ class InstanceToNodeMapperSpec extends Specification {
             1 * getEC2ForDefaultRegion() >> Mock(Ec2Client) {
                 1 * describeRegions() >> DescribeRegionsResponse.builder()
                         .regions(regions.collect({ r ->
+                            // Real AWS DescribeRegions responses return a bare hostname with no
+                            // URI scheme (e.g. "ec2.us-west-1.amazonaws.com"), not a full URL.
                             Region.builder()
                                     .regionName(r)
-                                    .endpoint("https://ec2.${r}.amazonaws.com".toString())
+                                    .endpoint("ec2.${r}.amazonaws.com".toString())
                                     .build()
                         }))
                         .build()
@@ -362,7 +364,7 @@ class InstanceToNodeMapperSpec extends Specification {
 
         where:
         endpoint       | endpointsFound|regions
-        'ALL_REGIONS' | ['https://ec2.us-west-1.amazonaws.com', 'https://ec2.us-east-1.amazonaws.com']|['us-west-1', 'us-east-1']
+        'ALL_REGIONS' | ['ec2.us-west-1.amazonaws.com', 'ec2.us-east-1.amazonaws.com']|['us-west-1', 'us-east-1']
 
     }
 


### PR DESCRIPTION
## Summary
- Customer (Syntax) reported a `NullPointerException: The URI scheme of endpointOverride must not be null.` from the `aws-ec2` Resource Model Source after configuring `Endpoint=ALL_REGIONS`.
- Root cause: AWS's `DescribeRegions` API returns bare hostnames with no URI scheme (e.g. `ec2.us-west-1.amazonaws.com`), which `InstanceToNodeMapper.determineEndpoints()` passes straight through as the resolved endpoint. `EC2SupplierImpl.getEC2ForEndpoint()` then calls `URI.create(endpoint)`, which does not throw on a schemeless string, followed by AWS SDK v2's `Ec2ClientBuilder.endpointOverride(URI)`, which does throw once the client is built.
- This also silently broke signing-region derivation for `ALL_REGIONS`: `regionFromEndpoint()` calls `URI.create(endpoint).getHost()`, which returns `null` for a schemeless URI, so the signing region was quietly falling back to the default region instead of the actual target region.
- Fix: normalize the endpoint string to include a scheme (defaulting to `https://`) in `EC2SupplierImpl.getEC2ForEndpoint()` before it's used for both signing-region derivation and `endpointOverride()`. This is the single choke point both the `ALL_REGIONS` path and the documented manual comma-separated-endpoint-list path flow through.
- Also corrected `InstanceToNodeMapperSpec`'s `ALL_REGIONS` test mock, which fabricated `region.endpoint()` values that already included a scheme — not representative of real AWS API responses, which is why this regression wasn't caught by CI.
- Added `EC2SupplierImplSpec` with direct coverage of `getEC2ForEndpoint()` for both a bare hostname and a fully-qualified URL, since the existing `InstanceToNodeMapperSpec` mocks `EC2Supplier` entirely and never exercises the real client-construction code path where this bug lives.

Ref: RUN-4795

(Supersedes #224, which was opened from a fork before I had direct push access to this repo.)

## Test plan
- [x] `./gradlew test` passes
- [x] Verified `EC2SupplierImplSpec` reproduces the exact reported NPE when the fix is reverted, and passes with the fix applied