### PR TITLE
[RUN-4933] Bump rundeck-core to 6.2.0-20260908 (CVE-2026-19032)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ commonsBeanutils = "1.11.0"
 groovy = "4.0.33"
 jacksonDatabind = "2.22.2"
 objenesis = "3.6"
-rundeckCore = "6.1.0-20260803"
+rundeckCore = "6.2.0-20260908"
 slf4j = "2.0.18"
 spock = "2.4-groovy-4.0"
 # Security overrides for transitive dependencies


### PR DESCRIPTION
## What

Bumps `rundeck-core` from `6.1.0-20260803` to `6.2.0-20260908`.

## Why

CVE-2026-19032: `6.1.0-20260803` pulls in a vulnerable transitive
Jackson version. `6.2.0-20260908` includes the fix.

## Note

`6.2.0-20260908` was published today. If the CI build here fails to
resolve it, that's expected propagation lag on the Sonatype snapshots
feed, not a real problem with this change - rerun the build once it's
synced.